### PR TITLE
feat: add role-based authorization with admin endpoint

### DIFF
--- a/alembic/versions/b3c7a1d9e2f4_add_user_role_column.py
+++ b/alembic/versions/b3c7a1d9e2f4_add_user_role_column.py
@@ -1,0 +1,31 @@
+"""add user role column
+
+Revision ID: b3c7a1d9e2f4
+Revises: af85030565fd
+Create Date: 2026-02-02 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b3c7a1d9e2f4"
+down_revision: str | Sequence[str] | None = "af85030565fd"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add role column to user table."""
+    op.add_column(
+        "user", sa.Column("role", sa.String(length=50), server_default="user", nullable=False)
+    )
+
+
+def downgrade() -> None:
+    """Remove role column from user table."""
+    op.drop_column("user", "role")

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,3 +1,10 @@
+from app.auth.roles import UserRole, require_role
 from app.auth.users import auth_backend, current_active_user, fastapi_users
 
-__all__ = ["auth_backend", "current_active_user", "fastapi_users"]
+__all__ = [
+    "UserRole",
+    "auth_backend",
+    "current_active_user",
+    "fastapi_users",
+    "require_role",
+]

--- a/app/auth/roles.py
+++ b/app/auth/roles.py
@@ -1,0 +1,31 @@
+from enum import StrEnum
+
+from fastapi import Depends, HTTPException, status
+
+from app.auth.users import current_active_user
+from app.models.user import User
+
+
+class UserRole(StrEnum):
+    USER = "user"
+    ADMIN = "admin"
+
+
+def require_role(*allowed_roles: str):
+    """Dependency factory that checks the user has one of the allowed roles.
+
+    Superusers bypass the role check. Returns the authenticated User so
+    routes don't need a separate ``Depends(current_active_user)``.
+    """
+
+    async def _check_role(user: User = Depends(current_active_user)) -> User:
+        if user.is_superuser:
+            return user
+        if user.role not in allowed_roles:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Insufficient permissions",
+            )
+        return user
+
+    return _check_role

--- a/app/main.py
+++ b/app/main.py
@@ -16,7 +16,7 @@ from app.config import settings
 from app.features import router as features_router
 from app.logging import setup_logging
 from app.models.user import User
-from app.routers import notes_router
+from app.routers import admin_router, notes_router
 from app.routers.auth_refresh import router as auth_refresh_router
 from app.schemas.user import UserCreate, UserRead
 from app.telemetry import setup_telemetry
@@ -135,6 +135,7 @@ async def request_logging_middleware(request: Request, call_next) -> Response:
 
 
 # API routes
+app.include_router(admin_router)
 app.include_router(notes_router)
 app.include_router(features_router)
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,4 +1,6 @@
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
+from sqlalchemy import String
+from sqlalchemy.orm import Mapped, mapped_column
 
 from app.database import Base
 
@@ -13,9 +15,8 @@ class User(SQLAlchemyBaseUserTableUUID, Base):
     - is_active: whether user can authenticate
     - is_superuser: admin privileges
     - is_verified: email verification status
-
-    Add custom fields below if needed, e.g.:
-        display_name: Mapped[str | None] = mapped_column(String(100))
     """
 
-    pass
+    role: Mapped[str] = mapped_column(
+        String(50), default="user", server_default="user", nullable=False
+    )

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,3 +1,4 @@
+from app.routers.admin import router as admin_router
 from app.routers.notes import router as notes_router
 
-__all__ = ["notes_router"]
+__all__ = ["admin_router", "notes_router"]

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,0 +1,47 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.auth.roles import UserRole, require_role
+from app.database import get_async_session
+from app.models.user import User
+from app.schemas.user import UserRead
+
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+class RoleUpdate(BaseModel):
+    role: str
+
+
+@router.patch("/users/{user_id}/role", response_model=UserRead)
+async def update_user_role(
+    user_id: UUID,
+    body: RoleUpdate,
+    session: AsyncSession = Depends(get_async_session),
+    _admin: User = Depends(require_role("admin")),
+):
+    """Update a user's role. Requires admin role."""
+    # Validate role value against enum
+    try:
+        UserRole(body.role)
+    except ValueError:
+        valid = [r.value for r in UserRole]
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+            detail=f"Invalid role '{body.role}'. Must be one of: {valid}",
+        ) from None
+
+    target = await session.get(User, user_id)
+    if not target:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User not found",
+        )
+
+    target.role = body.role
+    await session.commit()
+    await session.refresh(target)
+    return target

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -6,7 +6,7 @@ from fastapi_users import schemas
 class UserRead(schemas.BaseUser[UUID]):
     """Schema for reading user data."""
 
-    pass
+    role: str = "user"
 
 
 class UserCreate(schemas.BaseUserCreate):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,31 @@ def other_user() -> User:
 
 
 @pytest.fixture
+def admin_user() -> User:
+    """A user with the admin role."""
+    return User(id=uuid4(), email="admin@example.com", hashed_password="fake", role="admin")
+
+
+@pytest.fixture
+def superuser() -> User:
+    """A superuser (bypasses role checks)."""
+    return User(id=uuid4(), email="super@example.com", hashed_password="fake", is_superuser=True)
+
+
+@pytest.fixture
 async def auth_client(client: AsyncClient, test_user: User) -> AsyncGenerator[AsyncClient, None]:
     """Client that authenticates as test_user via dependency override."""
     app.dependency_overrides[current_active_user] = lambda: test_user
+    try:
+        yield client
+    finally:
+        app.dependency_overrides.pop(current_active_user, None)
+
+
+@pytest.fixture
+async def admin_client(client: AsyncClient, admin_user: User) -> AsyncGenerator[AsyncClient, None]:
+    """Client that authenticates as admin_user via dependency override."""
+    app.dependency_overrides[current_active_user] = lambda: admin_user
     try:
         yield client
     finally:

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,0 +1,137 @@
+from uuid import uuid4
+
+from httpx import AsyncClient
+
+from app.auth import current_active_user
+from app.main import app
+from app.models.user import User
+
+
+class TestRoleAccess:
+    """Test that role-based access control works correctly."""
+
+    async def test_admin_can_access_admin_route(
+        self, admin_client: AsyncClient, admin_user: User, session
+    ):
+        """Admin users can access admin-gated endpoints."""
+        # Create a target user in the DB to update
+        target = User(id=uuid4(), email="target@example.com", hashed_password="fake")
+        session.add(target)
+        await session.commit()
+
+        response = await admin_client.patch(
+            f"/admin/users/{target.id}/role",
+            json={"role": "admin"},
+        )
+        assert response.status_code == 200
+
+    async def test_regular_user_gets_403(self, auth_client: AsyncClient, test_user: User):
+        """Regular users are forbidden from admin endpoints."""
+        response = await auth_client.patch(
+            f"/admin/users/{uuid4()}/role",
+            json={"role": "admin"},
+        )
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Insufficient permissions"
+
+    async def test_superuser_bypasses_role_check(
+        self, client: AsyncClient, superuser: User, session
+    ):
+        """Superusers can access admin endpoints regardless of their role."""
+        app.dependency_overrides[current_active_user] = lambda: superuser
+        try:
+            target = User(id=uuid4(), email="target2@example.com", hashed_password="fake")
+            session.add(target)
+            await session.commit()
+
+            response = await client.patch(
+                f"/admin/users/{target.id}/role",
+                json={"role": "admin"},
+            )
+            assert response.status_code == 200
+        finally:
+            app.dependency_overrides.pop(current_active_user, None)
+
+
+class TestRoleUpdate:
+    """Test the PATCH /admin/users/{user_id}/role endpoint."""
+
+    async def test_update_role_success(self, admin_client: AsyncClient, admin_user: User, session):
+        """Successfully update a user's role."""
+        target = User(id=uuid4(), email="target3@example.com", hashed_password="fake")
+        session.add(target)
+        await session.commit()
+
+        response = await admin_client.patch(
+            f"/admin/users/{target.id}/role",
+            json={"role": "admin"},
+        )
+        assert response.status_code == 200
+        data = response.json()
+        assert data["role"] == "admin"
+        assert data["email"] == "target3@example.com"
+
+    async def test_invalid_role_returns_422(
+        self, admin_client: AsyncClient, admin_user: User, session
+    ):
+        """Invalid role value returns 422."""
+        target = User(id=uuid4(), email="target4@example.com", hashed_password="fake")
+        session.add(target)
+        await session.commit()
+
+        response = await admin_client.patch(
+            f"/admin/users/{target.id}/role",
+            json={"role": "supervillain"},
+        )
+        assert response.status_code == 422
+
+    async def test_user_not_found_returns_404(self, admin_client: AsyncClient, admin_user: User):
+        """Updating a non-existent user returns 404."""
+        response = await admin_client.patch(
+            f"/admin/users/{uuid4()}/role",
+            json={"role": "admin"},
+        )
+        assert response.status_code == 404
+        assert response.json()["detail"] == "User not found"
+
+
+class TestAuthMeIncludesRole:
+    """Test that /auth/me returns the role field."""
+
+    async def test_me_returns_role_for_regular_user(self, client: AsyncClient):
+        user = User(
+            id=uuid4(),
+            email="me@example.com",
+            hashed_password="fake",
+            role="user",
+            is_active=True,
+            is_superuser=False,
+            is_verified=False,
+        )
+        app.dependency_overrides[current_active_user] = lambda: user
+        try:
+            response = await client.get("/auth/me")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["role"] == "user"
+        finally:
+            app.dependency_overrides.pop(current_active_user, None)
+
+    async def test_me_returns_role_for_admin(self, client: AsyncClient):
+        user = User(
+            id=uuid4(),
+            email="meadmin@example.com",
+            hashed_password="fake",
+            role="admin",
+            is_active=True,
+            is_superuser=False,
+            is_verified=False,
+        )
+        app.dependency_overrides[current_active_user] = lambda: user
+        try:
+            response = await client.get("/auth/me")
+            assert response.status_code == 200
+            data = response.json()
+            assert data["role"] == "admin"
+        finally:
+            app.dependency_overrides.pop(current_active_user, None)


### PR DESCRIPTION
Introduce a `role` field on the User model (default: "user") backed by
  a plain String(50) column, a `require_role()` dependency factory that
  gates routes by role while letting superusers bypass, and a dedicated
  PATCH /admin/users/{user_id}/role endpoint for admins to update roles.

  UserCreate and UserUpdate are unchanged — role is read-only via UserRead
  and writable only through the admin endpoint.