### PR TITLE
chore: backport security improvements from audit

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @amrtgaber

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -81,5 +81,19 @@ async def get_user_manager(
 
 fastapi_users = FastAPIUsers[User, UUID](get_user_manager, [auth_backend])
 
-current_active_user = fastapi_users.current_user(active=True)
-current_superuser = fastapi_users.current_user(active=True, superuser=True)
+_fastapi_users_current_active = fastapi_users.current_user(active=True)
+_fastapi_users_current_superuser = fastapi_users.current_user(active=True, superuser=True)
+
+
+async def current_active_user(
+    user: User = Depends(_fastapi_users_current_active),
+) -> User:
+    structlog.contextvars.bind_contextvars(user_id=str(user.id))
+    return user
+
+
+async def current_superuser(
+    user: User = Depends(_fastapi_users_current_superuser),
+) -> User:
+    structlog.contextvars.bind_contextvars(user_id=str(user.id))
+    return user

--- a/app/main.py
+++ b/app/main.py
@@ -48,6 +48,20 @@ limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+MAX_REQUEST_BODY_SIZE = 1_048_576  # 1 MB
+
+
+@app.middleware("http")
+async def limit_request_body_size(request: Request, call_next) -> Response:
+    content_length = request.headers.get("content-length")
+    if content_length and int(content_length) > MAX_REQUEST_BODY_SIZE:
+        return JSONResponse(
+            status_code=413,
+            content={"detail": "Request body too large"},
+        )
+    return await call_next(request)
+
+
 # --- Auth routes ---
 # Custom refresh/logout routes (included before FastAPI-Users so /auth/jwt/logout is shadowed)
 app.include_router(auth_refresh_router)

--- a/app/schemas/note.py
+++ b/app/schemas/note.py
@@ -8,7 +8,11 @@ class NoteBase(BaseModel):
     """Base schema with shared note fields."""
 
     title: str = Field(..., min_length=1, max_length=200, examples=["Meeting notes"])
-    body: str | None = Field(None, examples=["Discussed project timeline and milestones."])
+    body: str | None = Field(
+        None,
+        max_length=10_000,
+        examples=["Discussed project timeline and milestones."],
+    )
 
 
 class NoteCreate(NoteBase):
@@ -21,7 +25,7 @@ class NoteUpdate(BaseModel):
     """Schema for updating a note. All fields optional."""
 
     title: str | None = Field(None, min_length=1, max_length=200)
-    body: str | None = None
+    body: str | None = Field(None, max_length=10_000)
 
 
 class NoteRead(NoteBase):

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,6 +1,7 @@
 from uuid import UUID
 
 from fastapi_users import schemas
+from pydantic import Field
 
 
 class UserRead(schemas.BaseUser[UUID]):
@@ -13,10 +14,10 @@ class UserRead(schemas.BaseUser[UUID]):
 class UserCreate(schemas.BaseUserCreate):
     """Schema for creating a new user."""
 
-    name: str | None = None
+    name: str | None = Field(None, max_length=100)
 
 
 class UserUpdate(schemas.BaseUserUpdate):
     """Schema for updating user data."""
 
-    name: str | None = None
+    name: str | None = Field(None, max_length=100)


### PR DESCRIPTION
## Summary

Backports template-level fixes discovered during a security / analytics / legal audit across projects spawned from this template. Full plan in `BACKPORT_FROM_AUDIT.md` (templates root).

## Changes

**Security**
- `feat`: 1MB request body size middleware in `app/main.py`. FastAPI/Starlette enforces no default limit, so without this a malicious client could POST a multi-GB JSON payload and the server would happily try to parse it. Returns HTTP 413 when `Content-Length` exceeds the threshold.
- `feat(schemas)`: add `Field(max_length=...)` bounds to user-supplied strings.
  - `NoteBase.body` → 10,000 chars (was unbounded)
  - `UserCreate.name` / `UserUpdate.name` → 100 chars (were unbounded)
  - `UserRead.name` intentionally left unbounded (response shape, data originates from our DB)
  - Demonstrates the pattern so new projects copy it.

**Observability**
- `feat(logging)`: bind `user_id` to structlog contextvars on authentication. Wraps the fastapi-users `current_active_user` and `current_superuser` dependencies transparently so every log emitted during an authenticated request carries `user_id` alongside the existing `request_id`. No caller changes required — the wrapping happens at the symbol level in `app/auth/users.py` and FastAPI's DI chain handles the rest.

**Scaffolding**
- `chore`: add top-level `permissions: contents: read` to `.github/workflows/ci.yml` (least-privilege `GITHUB_TOKEN`).
- `chore`: add `.github/CODEOWNERS` catch-all placeholder (`* @amrtgaber`) so spawned projects get review enforcement from day one.

## Test plan

- [x] `uv run ruff check .` — clean
- [x] `uv run ruff format --check .` — clean
- [x] `uv run pytest` — 21/21 passing
- [ ] Manual: POST a request with `Content-Length: 2000000` and verify 413 response
- [ ] Manual: authenticated request and verify `user_id` appears in structured log output alongside `request_id`
- [ ] Manual: POST a note with a 20,000-char body and verify 422 validation error