### PR TITLE
chore: bump CI actions onto the Node 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -22,7 +22,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync
       - run: uv run pytest


### PR DESCRIPTION
## What

Bump the two GitHub Actions used in CI to their current major versions:

- `actions/checkout` v4 → v6
- `astral-sh/setup-uv` v5 → v8

## Why

The previously pinned majors run on the **Node 20 action runtime**, which has reached end-of-life. GitHub progressively deprecates EOL action runtimes (as it did with Node 16, which began annotating every run with warnings). Both current majors run on the **Node 24** runtime.

Note: this repo is Python-only — there is no project Node version involved here. This is purely the Node runtime the JavaScript-based actions themselves execute on.