### PR TITLE
chore: align setup-uv pin with the rest of the repos (@v7)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -23,6 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v8.1.0
+      - uses: astral-sh/setup-uv@v7
       - run: uv sync
       - run: uv run pytest


### PR DESCRIPTION
Align the `astral-sh/setup-uv` pin with the floating-major convention used everywhere else in the repo (`checkout@v6`, `setup-node@v6`, `pnpm/action-setup@v6`) and with the majority of already-bumped repos in this org, which sit on `@v7`.

Both `@v7` and `@v8.1.0` run on Node 24 — this change is purely about consistency.