### PR TITLE
chore: release v1.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "api-template"
-version = "0.1.0"
+version = "1.0.0"
 description = "FastAPI template with async PostgreSQL and JWT auth"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
First tagged release. Promotes the current state of the template to a v1.0.0 baseline.

The recent /v1 route prefix migration, security backport, production-learnings sweep, and CI runtime modernization together form a coherent stable scaffold worth pinning.

**Going forward:** manual version bumps on meaningful PRs; release notes via GitHub Releases (no CHANGELOG file).