### PR TITLE
chore: add SPDX license headers and NOTICE file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - run: uv sync
       - run: uv run ruff check .
       - run: uv run ruff format --check .
+      - run: uv run python scripts/license_header.py --check
 
   test:
     runs-on: ubuntu-latest

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,4 @@
+AG Tech API Template
+Copyright 2026 AG Technology Group LLC
+
+This product includes software developed by AG Technology Group LLC.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import asyncio
 from logging.config import fileConfig
 

--- a/alembic/versions/af85030565fd_initial_schema.py
+++ b/alembic/versions/af85030565fd_initial_schema.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """initial schema
 
 Revision ID: af85030565fd

--- a/alembic/versions/b3c7a1d9e2f4_add_user_role_column.py
+++ b/alembic/versions/b3c7a1d9e2f4_add_user_role_column.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """add user role column
 
 Revision ID: b3c7a1d9e2f4

--- a/alembic/versions/c4e8f2a1b5d7_add_user_name_column.py
+++ b/alembic/versions/c4e8f2a1b5d7_add_user_name_column.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """add user name column
 
 Revision ID: c4e8f2a1b5d7

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+

--- a/app/analytics.py
+++ b/app/analytics.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Analytics event abstraction with a pluggable backend."""
 
 from __future__ import annotations

--- a/app/auth/__init__.py
+++ b/app/auth/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from app.auth.roles import UserRole, require_role
 from app.auth.users import auth_backend, current_active_user, fastapi_users
 

--- a/app/auth/backend.py
+++ b/app/auth/backend.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from fastapi_users.authentication import AuthenticationBackend, CookieTransport, JWTStrategy
 
 from app.config import settings

--- a/app/auth/refresh.py
+++ b/app/auth/refresh.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import uuid
 from datetime import UTC, datetime, timedelta
 

--- a/app/auth/roles.py
+++ b/app/auth/roles.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 
 from fastapi import Depends, HTTPException, status

--- a/app/auth/security_logging.py
+++ b/app/auth/security_logging.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from enum import StrEnum
 
 import structlog

--- a/app/auth/users.py
+++ b/app/auth/users.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import AsyncGenerator
 from uuid import UUID
 

--- a/app/config.py
+++ b/app/config.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from pydantic import model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 

--- a/app/database.py
+++ b/app/database.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import AsyncGenerator
 
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine

--- a/app/features.py
+++ b/app/features.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Environment-variable-backed feature flags."""
 
 from __future__ import annotations

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """Structured logging configuration using structlog."""
 
 import logging

--- a/app/main.py
+++ b/app/main.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import time
 import uuid
 

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from app.models.note import Note
 from app.models.refresh_token import RefreshToken
 from app.models.user import User

--- a/app/models/note.py
+++ b/app/models/note.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import uuid
 from datetime import datetime
 

--- a/app/models/refresh_token.py
+++ b/app/models/refresh_token.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import uuid
 from datetime import datetime
 

--- a/app/models/user.py
+++ b/app/models/user.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from fastapi_users.db import SQLAlchemyBaseUserTableUUID
 from sqlalchemy import String
 from sqlalchemy.orm import Mapped, mapped_column

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from app.routers.admin import router as admin_router
 from app.routers.notes import router as notes_router
 

--- a/app/routers/admin.py
+++ b/app/routers/admin.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status

--- a/app/routers/auth_refresh.py
+++ b/app/routers/auth_refresh.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import UUID
 
 from fastapi import APIRouter, Cookie, Depends, Response

--- a/app/routers/notes.py
+++ b/app/routers/notes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, status

--- a/app/schemas/__init__.py
+++ b/app/schemas/__init__.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from app.schemas.note import NoteCreate, NoteRead, NoteUpdate
 from app.schemas.user import UserCreate, UserRead, UserUpdate
 

--- a/app/schemas/note.py
+++ b/app/schemas/note.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from datetime import datetime
 from uuid import UUID
 

--- a/app/schemas/user.py
+++ b/app/schemas/user.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import UUID
 
 from fastapi_users import schemas

--- a/app/telemetry.py
+++ b/app/telemetry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """OpenTelemetry auto-instrumentation for FastAPI."""
 
 from __future__ import annotations

--- a/scripts/license_header.py
+++ b/scripts/license_header.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stamp or verify SPDX license headers on Python sources.
+
+Usage:
+    python scripts/license_header.py --check    verify every tracked .py file (CI)
+    python scripts/license_header.py --fix      add the header where missing
+
+Default mode is --check. Re-running is safe: a file that already carries an
+SPDX identifier in its first lines is left untouched (idempotent), so the CI
+check and a manual --fix can never disagree.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+HEADER = (
+    "# SPDX-FileCopyrightText: 2026 AG Technology Group LLC\n"
+    "# SPDX-License-Identifier: Apache-2.0\n"
+)
+
+GENERATED_BANNER = re.compile(r"@generated|do not edit|automatically generated", re.IGNORECASE)
+ENCODING = re.compile(r"coding[:=]\s*[-\w.]+")
+
+
+def tracked_py_files() -> list[str]:
+    result = subprocess.run(
+        ["git", "ls-files", "*.py"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line]
+
+
+def classify(text: str) -> str:
+    """Return "stamped", "skip", or "needs"."""
+    lines = text.splitlines()
+    if GENERATED_BANNER.search("\n".join(lines[:15])):
+        return "skip"
+    if "SPDX-License-Identifier" in "\n".join(lines[:10]):
+        return "stamped"
+    return "needs"
+
+
+def apply_header(text: str) -> str:
+    """Insert the header below a shebang/encoding line, above everything else."""
+    lines = text.splitlines(keepends=True)
+    prefix: list[str] = []
+    if lines and lines[0].startswith("#!"):
+        prefix.append(lines.pop(0))
+    if lines and lines[0].lstrip().startswith("#") and ENCODING.search(lines[0]):
+        prefix.append(lines.pop(0))
+    while lines and lines[0].strip() == "":
+        lines.pop(0)
+    body = "".join(lines)
+    separator = "\n" if body else ""
+    return "".join(prefix) + HEADER + separator + body
+
+
+def main() -> int:
+    args = sys.argv[1:]
+    fix = "--fix" in args
+    explicit = [a for a in args if not a.startswith("--")]
+    files = explicit or tracked_py_files()
+
+    stamped: list[str] = []
+    already: list[str] = []
+    skipped: list[str] = []
+    missing: list[str] = []
+
+    for name in files:
+        path = Path(name)
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        status = classify(text)
+        if status == "skip":
+            skipped.append(name)
+        elif status == "stamped":
+            already.append(name)
+        elif fix:
+            path.write_text(apply_header(text), encoding="utf-8")
+            stamped.append(name)
+        else:
+            missing.append(name)
+
+    if fix:
+        print(
+            f"license-header: stamped {len(stamped)}, already {len(already)}, skipped {len(skipped)}"
+        )
+        for name in stamped:
+            print(f"  + {name}")
+    elif missing:
+        print(f"license-header: {len(missing)} file(s) missing an SPDX header:", file=sys.stderr)
+        for name in missing:
+            print(f"  - {name}", file=sys.stderr)
+        print('Run "uv run python scripts/license_header.py --fix" to add them.', file=sys.stderr)
+        return 1
+    else:
+        print(f"license-header: OK — {len(already)} stamped, {len(skipped)} skipped")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from collections.abc import AsyncGenerator
 from uuid import uuid4
 

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 """App-level / infrastructure route behaviour: security.txt and global rate limiting."""
 
 from httpx import AsyncClient

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 import importlib
 import os
 from datetime import UTC, datetime, timedelta

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import uuid4
 
 from httpx import AsyncClient

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 AG Technology Group LLC
+# SPDX-License-Identifier: Apache-2.0
+
 from uuid import uuid4
 
 from httpx import AsyncClient


### PR DESCRIPTION
## What

- Add SPDX license headers (`Apache-2.0`, AG Technology Group LLC) to every tracked Python source file (35 files).
- Add an attribution-only `NOTICE` at the repo root.

## Enforcement (CI-only)

- `scripts/license_header.py` — dependency-free, stdlib-only check/stamp tool.
  - The CI `lint` job runs `python scripts/license_header.py --check`.
  - Run `python scripts/license_header.py --fix` to stamp new files locally.
- Deliberately **not** wired into `.pre-commit-config.yaml`. This is a template repo: a local hook would be inherited by every clone and have to be ripped out. The check only verifies that an `SPDX-License-Identifier` line exists, so a downstream fork with its own copyright still passes.

## Skipped

Generated-banner files, vendored dirs, and non-source files (configs, lockfiles, `start.sh`).

## Verification

`ruff check` / `ruff format --check` clean, `pytest` (32) passing, and the check is idempotent (35 stamped / 0 missing).
