### PR TITLE
Document the upstream tracking for the FastAPI hold

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,12 +62,12 @@ ignore = [
 known-first-party = ["app"]
 
 [tool.uv]
-# FastAPI 0.136+ breaks slowapi's SlowAPIMiddleware enforcement of
-# `default_limits` on undecorated routes (verified empirically: the global
-# rate-limit test fails on 0.140.x and passes on 0.135.x with all other
-# dependencies identical; independent of Starlette, slowapi, and Python
-# versions). slowapi is low-activity upstream, so hold FastAPI until slowapi
-# is fixed or replaced with a middleware built directly on `limits`.
-# Starlette is capped alongside it since slowapi has never been validated
-# against Starlette 1.x.
+# FastAPI >=0.137 changed how included routers' routes are resolved, which
+# breaks slowapi's SlowAPIMiddleware enforcement of `default_limits` on
+# undecorated routes mounted via include_router (verified empirically here:
+# the global rate-limit test fails on 0.140.x and passes on 0.135.x with all
+# other dependencies identical). Known upstream as slowapi issue #281 with
+# fix PR #282; drop this hold once a slowapi release containing that fix
+# ships. Starlette is capped alongside it since slowapi has never been
+# validated against Starlette 1.x.
 constraint-dependencies = ["fastapi<0.136", "starlette<1.0"]


### PR DESCRIPTION
The `fastapi<0.136` constraint added during the dependency refresh was root-caused empirically but lacked an upstream reference. The breakage is [slowapi issue #281](https://github.com/laurentS/slowapi/issues/281) — `default_limits` not enforced for routes mounted via `include_router` on `fastapi>=0.137` — with open fix [PR #282](https://github.com/laurentS/slowapi/pull/282).

This updates the constraint comment to cite the issue and state the exact unpin condition: a slowapi release containing that fix.