### PR TITLE
chore: restrict uv Dependabot updates to the lockfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    # Maintain uv.lock only; leave the `>=` floors in pyproject.toml alone.
+    # Without this, Dependabot defaults to BumpVersions for non-libraries and
+    # ratchets each floor up to whatever just resolved — producing PRs that
+    # change no installed version (the lock is already there) while narrowing
+    # the declared minimum for anyone scaffolding from this template. The lock
+    # is what CI exercises; the floors are a compatibility declaration.
+    versioning-strategy: "lockfile-only"
     groups:
       python-minor-patch:
         update-types:


### PR DESCRIPTION
## Summary

Adds `versioning-strategy: "lockfile-only"` to the `uv` ecosystem block in `.github/dependabot.yml`.

## Why

Dependabot's uv integration inherits the Python update checker, which resolves its strategy as `library? ? WidenRanges : BumpVersions`. This project is a non-library, so the default is **BumpVersions** — raise each `>=` floor in `pyproject.toml` to whatever version just resolved.

That generated a recurring class of PR with no functional content. #33 (`fastapi-users>=15.0.0` → `>=15.0.5`) and #34 (`uvicorn[standard]>=0.41.0` → `>=0.51.0`) were both closed as no-ops: `uv.lock` already resolved 15.0.5 and 0.51.0 respectively, so each PR's entire effect was one line in `pyproject.toml` plus the mirrored `requires-dist` metadata line in the lock. Zero package version changes. #34's proposed floor was already stale on arrival (uvicorn is at 0.52.1).

The floors are a compatibility declaration inherited by every project scaffolded from this template; `uv.lock` is what CI actually exercises. Ratcheting the floors adds review noise without adding safety, and quietly narrows the declared minimum for consumers.

## Scope

- Grouping (`python-minor-patch`) is unchanged — real lockfile bumps like #36 still arrive grouped.
- `github-actions` and `docker` don't support `versioning-strategy`; those blocks are untouched.
- No effect on security updates, which bypass `versioning-strategy`.

## Verification

`.github/dependabot.yml` parses; the uv block retains its group config and the ecosystem list is unchanged. Effect is observable on the next weekly run.